### PR TITLE
handlers: include sender in 0x2b chat re-broadcast (fix #3)

### DIFF
--- a/accd/handlers.c
+++ b/accd/handlers.c
@@ -655,7 +655,7 @@ h_chat(struct Server *s, struct Conn *c,
 		    wr_i32(&out, 0) == 0 &&
 		    wr_u8(&out, 0) == 0)
 			(void)bcast_all(s, out.data, out.wpos,
-			    c->conn_id);
+			    BCAST_EXCEPT_NONE);
 		bb_free(&out);
 	}
 out:


### PR DESCRIPTION
Fixes #3.

Single-line change: `c->conn_id` → `BCAST_EXCEPT_NONE` in the `0x2a` ACP_CHAT handler at `accd/handlers.c:658`.

The handler was excluding the sender from its own 0x2b chat re-broadcast, so each driver could see everyone else's chat in the in-game panel but never their own. Switched to `BCAST_EXCEPT_NONE` to match what the upstream Kunos exe does and what every other `chat_broadcast` call site in `accd/chat.c` already uses.

Verified the bug on accd `0.3.72` with 6 concurrent drivers (see issue #3 for log captures with `CHAT TBH: hello` arriving at the server but never echoing back to me); the fix makes own messages appear in the chat panel as expected.

Nothing else changed.