### PR TITLE
console: add say <message> admin command (chat as 'SERVER' in player panel)

### DIFF
--- a/accd/chat.c
+++ b/accd/chat.c
@@ -119,6 +119,34 @@ chat_broadcast(struct Server *s, const char *text, uint8_t chat_type)
 	bb_free(&out);
 }
 
+/*
+ * Same wire as the player-relay path in handlers.c::h_chat (0x2b
+ * with chat_type=0) but the sender label is operator-supplied so
+ * the message renders in the in-game chat panel under a fake
+ * driver name (e.g. "SERVER", "ADMIN").  Useful for the `say`
+ * console command -- Race-Control broadcasts (chat_broadcast
+ * above) land in the dedicated overlay lane which most operators
+ * expect for system notifications, but operator chatter to
+ * drivers needs the regular chat panel.
+ */
+void
+chat_broadcast_as(struct Server *s, const char *sender, const char *text)
+{
+	struct ByteBuf out;
+
+	if (text == NULL || text[0] == '\0' ||
+	    sender == NULL || sender[0] == '\0')
+		return;
+	bb_init(&out);
+	if (wr_u8(&out, SRV_CHAT_OR_STATE) == 0 &&
+	    wr_str_a(&out, sender) == 0 &&
+	    wr_str_a(&out, text) == 0 &&
+	    wr_i32(&out, 0) == 0 &&
+	    wr_u8(&out, 0) == 0)
+		(void)bcast_all(s, out.data, out.wpos, BCAST_EXCEPT_NONE);
+	bb_free(&out);
+}
+
 void
 chat_do_bop(struct Server *s, const char *args, int is_ballast,
     char *reply, size_t replysz)

--- a/accd/chat.h
+++ b/accd/chat.h
@@ -72,6 +72,15 @@ int	chat_car_by_racenum(struct Server *s, int num);
 void	chat_broadcast(struct Server *s, const char *text, uint8_t type);
 
 /*
+ * Build and broadcast a 0x2b chat message in the player lane
+ * (chat_type=0) under a custom sender name.  Used by the `say`
+ * admin-console command so the message lands in the AC2 client's
+ * chat panel rather than the Race-Control overlay.
+ */
+void	chat_broadcast_as(struct Server *s, const char *sender,
+	    const char *text);
+
+/*
  * Action helpers.  Each performs the mutation, broadcasts to
  * in-game clients, and writes a human-readable reply to
  * reply[replysz] if non-NULL.

--- a/accd/console.c
+++ b/accd/console.c
@@ -102,6 +102,7 @@ cmd_help(void)
 	reply("  restrictor <n> %%  assign restrictor");
 	reply("  track [name]     show or change track");
 	reply("  connections      list connections (also broadcasts)");
+	reply("  say <message>    chat as 'SERVER' in the player chat panel");
 	reply("  debug            toggle debug tracing");
 	reply("  quit             shut down the server");
 }
@@ -386,6 +387,16 @@ console_dispatch(struct Server *s, const char *line)
 		}
 	} else if (chat_prefix(p, "connections")) {
 		cmd_connections(s);
+	} else if (chat_prefix(p, "say")) {
+		const char *arg = p + 3;
+		while (*arg == ' ')
+			arg++;
+		if (*arg == '\0') {
+			reply("usage: say <message>");
+		} else {
+			chat_broadcast_as(s, "SERVER", arg);
+			reply("said: %s", arg);
+		}
 	} else if (chat_prefix(p, "debug")) {
 		g_debug = !g_debug;
 		reply("debug tracing %s", g_debug ? "enabled" : "disabled");


### PR DESCRIPTION
The admin console only had `chat_broadcast` (RC_SENDER + `chat_type=4`) for outbound chat, which the AC2 client renders in the Race-Control overlay lane and not the regular chat panel. Operators who want to push league announcements / race-start countdowns / free-form notes to the chat panel had no native option short of joining the server as a spectator.

This PR adds a `say <message>` admin-console command that broadcasts a `0x2b` chat relay under a fake sender (`"SERVER"`) with `chat_type=0` — the same wire shape `handlers.c::h_chat` uses for driver-to-driver chat. The message lands directly in the chat panel like a regular player message, just under a clearly-marked operator name.

## Change shape

- `accd/chat.h` — declare `chat_broadcast_as(s, sender, text)`.
- `accd/chat.c` — implement it adjacent to `chat_broadcast()` (same wire, just with operator-supplied sender and hard-coded `chat_type=0`).
- `accd/console.c` — new `say` arm between `connections` and `debug`, plus a help line.

3 files, +48 lines, no removals.

## Design choices

- **Sender hard-coded to `"SERVER"`** for this PR to keep the surface small. If you'd rather expose this as a `settings.json` knob (e.g. `consoleSayName`) or a CLI arg, happy to follow up — picked the simplest thing that works.
- **`chat_type=0`** (player lane) on purpose. `chat_broadcast` with `chat_type=4` is kept untouched for everything that genuinely belongs in the Race-Control overlay (kick / ban / penalty / weekend-reset announcements).
- **Placement** of the `say` arm: right after `connections` (the previous broadcast-style command) and before `debug` in `console.c::console_handle`. No prefix collision; "say" is 3 chars and unique among the existing console commands.

## Compile + smoke test

- `make -C accd` on `debian:bookworm-slim amd64`, `gcc 12`, full hardening (`-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE`) — clean, no new warnings.
- Smoke-tested on a 0.3.72 + this patch + the issue #3 sender fix (PR #4) build inside a Docker container with a running ACC client: `echo "say hello drivers" > /tmp/cmd` shows up in the in-game chat panel as `SERVER: hello drivers`, exactly as expected.

## Use case for the broader ecosystem

Most accd operators eventually want a runtime way to address drivers without changing seats — race-start "5 minutes go go go", "Round 1 cancelled, see Discord", penalty announcements outside the formal Race-Control flow, etc. The existing admin-side options (kick, restart, weekend-reset) all carry pre-baked text via `chat_broadcast`; `say` is the missing free-form counterpart and uses the chat panel (rather than the Race-Control overlay), which is where drivers' eyes are anyway during a session.

Happy to iterate on naming, sender configurability, or the command's placement.