### PR TITLE
fix(handlers): snapshot last lap splits before per-lap reset

### DIFF
--- a/accd/handlers.c
+++ b/accd/handlers.c
@@ -369,6 +369,18 @@ h_sector_split_single(struct Server *s, struct Conn *c,
 			race->out_of_track_latched = 0;
 			race->cuts_this_lap = 0;
 			race->last_cut_ms = 0;
+			/*
+			 * Snapshot the just-completed lap's splits BEFORE the
+			 * per-lap sector_ms reset, so results.c can emit them
+			 * in the per-car "lastSplits" field (which would
+			 * otherwise read back as [0,0,0]).  Captures both
+			 * valid and cut completions — matches kunos semantics
+			 * (the last lap shown in the live timetable is the
+			 * last lap completed, regardless of validity).
+			 */
+			race->last_lap_splits_ms[0] = race->sector_ms[0];
+			race->last_lap_splits_ms[1] = race->sector_ms[1];
+			race->last_lap_splits_ms[2] = race->sector_ms[2];
 			race->sector_ms[0] = 0;
 			race->sector_ms[1] = 0;
 			race->sector_ms[2] = 0;
@@ -482,9 +494,18 @@ h_sector_split_single(struct Server *s, struct Conn *c,
 			int is_inlap = (cf & 0x0008) != 0;
 			int session_over = (cf & 0x0400) != 0;
 			int lm = lap_ms < 0 ? 0 : lap_ms;
-			int s1 = race->sector_ms[0] < 0 ? 0 : race->sector_ms[0];
-			int s2 = race->sector_ms[1] < 0 ? 0 : race->sector_ms[1];
-			int s3 = race->sector_ms[2] < 0 ? 0 : race->sector_ms[2];
+			/*
+			 * sector_ms[] was reset above (per-lap reset).  Read
+			 * the splits from the freshly-taken last_lap_splits_ms
+			 * snapshot so the Kunos "Lap" log line carries the
+			 * real S1/S2/S3 times for accweb-style scrapers.
+			 */
+			int s1 = race->last_lap_splits_ms[0] < 0
+			    ? 0 : race->last_lap_splits_ms[0];
+			int s2 = race->last_lap_splits_ms[1] < 0
+			    ? 0 : race->last_lap_splits_ms[1];
+			int s3 = race->last_lap_splits_ms[2] < 0
+			    ? 0 : race->last_lap_splits_ms[2];
 			uint8_t didx = s->cars[c->car_id].current_driver_index;
 			char tail[64];
 

--- a/accd/results.c
+++ b/accd/results.c
@@ -258,9 +258,19 @@ results_write(struct Server *s)
 		fprintf(f, "        \"timing\": {\n");
 		fprintf(f, "          \"lastLap\": %d,\n",
 		    car->race.last_lap_ms);
+		/*
+		 * lastSplits must reflect the splits of the most recently
+		 * completed lap.  Read from last_lap_splits_ms (snapshot
+		 * taken in h_sector_split_single before the per-lap
+		 * sector_ms reset) — reading sector_ms directly would
+		 * yield [0,0,0] right after a lap completion, or the
+		 * in-progress partial splits of the lap currently being
+		 * driven (e.g. [s0, s1, 0]) if dumped mid-lap.
+		 */
 		fprintf(f, "          \"lastSplits\": [%d, %d, %d],\n",
-		    car->race.sector_ms[0], car->race.sector_ms[1],
-		    car->race.sector_ms[2]);
+		    car->race.last_lap_splits_ms[0],
+		    car->race.last_lap_splits_ms[1],
+		    car->race.last_lap_splits_ms[2]);
 		fprintf(f, "          \"bestLap\": %d,\n",
 		    car->race.best_lap_ms);
 		fprintf(f, "          \"bestSplits\": [%d, %d, %d],\n",

--- a/accd/state.h
+++ b/accd/state.h
@@ -217,6 +217,14 @@ struct CarRaceState {
 	int32_t		last_lap_ms;
 	int32_t		current_lap_ms;
 	int32_t		sector_ms[3];
+	/*
+	 * Snapshot of sector_ms[] taken at lap-completion just before
+	 * the per-lap reset, so results.c's "lastSplits" field reflects
+	 * the splits of the most recently completed lap (matches kunos
+	 * exe semantics) instead of always reading 0 after the reset.
+	 * Captures both valid and invalid (cut / out-lap) completions.
+	 */
+	int32_t		last_lap_splits_ms[3];
 	int32_t		best_sectors_ms[3];
 	int32_t		race_time_ms;
 	int32_t		lap_history_ms[ACC_LAP_HISTORY];


### PR DESCRIPTION
Snapshots `sector_ms[]` into a new `last_lap_splits_ms[3]` field on `CarRaceState` just before the per-lap reset in `h_sector_split_single`, and reads from this snapshot in `results.c` (`lastSplits` JSON field) and in the Kunos `Lap` log line (S1/S2/S3 cells).

Before this change:
- `results.json::lastSplits` was always `[0, 0, 0]` for any driver who completed a lap (the JSON write happens AFTER the per-lap reset)
- The Kunos `Lap` log line always emitted `S1 0:0:0, S2 0:0:0, S3 0:0:0`
- Mid-session dumps showed partial in-progress splits like `[s0, s1, 0]` (the splits of the lap currently being driven, not the last completed one)

Captures both valid and cut completions — matches the Kunos timetable semantic ("last lap shown" includes invalidated laps).

## Test plan
- Run a quali/race with at least one completed lap
- Check `results/*.json` per-car `lastSplits` shows the splits of the last completed lap
- Check `docker logs` `Lap` line shows non-zero `S1/S2/S3`

Fixes thomasbourimech/assettocorsa_competizione_server#4
