### PR TITLE
fix(handlers): trigger 0x36 leaderboard emit on lap completion

### DIFF
--- a/accd/handlers.c
+++ b/accd/handlers.c
@@ -520,6 +520,19 @@ h_sector_split_single(struct Server *s, struct Conn *c,
 
 		session_recompute_standings(s);
 
+		/*
+		 * Request a 0x36 leaderboard re-broadcast.  Without this,
+		 * the AC2 client never sees the updated last_lap / lap_count
+		 * / position columns until the next phase boundary or
+		 * conn_drop emits a 0x36 — so the entire in-race timetable
+		 * stays blank for the duration of the session.  The deep-
+		 * compare gate in broadcast_leaderboard_if_changed dedupes
+		 * any frame that happens to match the cached bytes (the
+		 * earlier "over-emit on formation crossings" concern), so
+		 * unconditional request here is safe.
+		 */
+		leaderboard_request_emit(s);
+
 		if (s->session.phase == PHASE_OVERTIME) {
 			session_overtime_car_finished(s);
 			session_quali_drop_eligibility(s, c->car_id);


### PR DESCRIPTION
`h_sector_split_single` ran `session_recompute_standings` to update per-car positions but never set the `leaderboard_pending` flag, so the AC2 client never received an updated `0x36 SRV_LEADERBOARD_BCAST` frame carrying the new `last_lap_ms` / `lap_count` / `position` columns.

Result: the in-race timetable stays blank for the whole session (no chrono, lap counter frozen at 0) even though the server's internal state has the right values.

The pre-existing comment in `tick.c:1042-1056` argued that kunos omits `0x36` on `lap_count++` from formation crossings; **live testing on Monza GT3 (2026-05-25) shows AC2 clients DO require a `0x36` fan-out after every real lap completion to refresh their timetable**.

Trigger it here; the deep-compare gate in `broadcast_leaderboard_if_changed` dedupes any frame whose bytes coincidentally match the previous emit (so a stray formation-lap `0x21` won't cause a real over-emit).

## Test plan
- Driver completes a lap on a fresh server
- AC2 client's chrono, lap counter, and previous lap time all populate
- Without this fix: all three stay at 0 forever

Fixes thomasbourimech/assettocorsa_competizione_server#7
