### PR TITLE
fix(handshake): 0x3e session_result_header type_code mapping (Q=3, R=80)

### DIFF
--- a/accd/handshake.c
+++ b/accd/handshake.c
@@ -481,11 +481,25 @@ write_session_result_header(struct ByteBuf *bb,
 	uint8_t dow_minus_one = def->day_of_weekend > 0
 	    ? (uint8_t)(def->day_of_weekend - 1) : 0;
 
+	/*
+	 * type_code mapping verified by pcap diff against kunos
+	 * accServer.exe (zolder Q5+R10, 2026-05-25):
+	 *   - Q: kunos emits u16=3   (was 4)
+	 *   - R: kunos emits u16=80  (was 5)
+	 *   - P: kunos emits u16=2   (inferred, not pcap-verified)
+	 *
+	 * Cross-check: write_session_mgr_state (the 0x28 header builder)
+	 * already emits type_code=3 for Q at offset +0x29 of the 0x28
+	 * payload — same session_type, different value here was a real
+	 * inconsistency.  The mis-mapped type_code caused the AC2 client
+	 * to drift in its 0x3e per-record parser and crash on drill-down
+	 * into the post-session results table.
+	 */
 	switch (def->session_type) {
-	case 0:		type_code = 3;	break;	/* P */
-	case 4:		type_code = 4;	break;	/* Q */
-	case 10:	type_code = 5;	break;	/* R */
-	default:	type_code = 3;	break;	/* default to P */
+	case 0:		type_code = 2;	break;	/* P */
+	case 4:		type_code = 3;	break;	/* Q (pcap verified) */
+	case 10:	type_code = 80;	break;	/* R (pcap verified) */
+	default:	type_code = 2;	break;	/* default to P */
 	}
 	if (wr_u8(bb, def->hour_of_day) < 0) return -1;
 	if (wr_u8(bb, 0) < 0) return -1;


### PR DESCRIPTION
The `write_session_result_header` `type_code` was mis-mapped by +1 for P/Q and completely wrong for R, causing AC2 clients to mis-parse the per-record header in the `0x3e SESSION_RESULTS` broadcast and crash on drill-down into the post-session results table.

## Pcap diff against kunos accServer.exe (zolder Q5+R10, 2026-05-25)
| Session | accd was | Wine sends | Verdict |
|---|---|---|---|
| Q (`session_type=4`) | u16=4 | u16=**3** | off-by-one |
| R (`session_type=10`) | u16=5 | u16=**80** (0x50) | completely wrong |

## Cross-check inside accd
The `write_session_mgr_state` builder (used for `0x28 LARGE_STATE_RESPONSE`) already emits `type_code=3` for Q at offset `+0x29` of the `0x28` payload — same `session_type` value, different code here was an internal inconsistency.

## Visible client symptom
After Q ends, the AC2 client shows the post-session table but crashes if the user clicks any result row to drill into the per-driver splits. On Wine accServer.exe (reference), the same drill-down works without crash.

## Wire dump
Wine Q 0x3e first 32 bytes: `3e 01 0d 00 01 00 00 80 3f 03 00 ...` (type_code=3 at offset 0x09)
accd Q 0x3e first 32 bytes: `3e 01 0d 00 01 00 00 80 3f 04 00 ...` (type_code=4 — WRONG)

Wine R 0x3e (offset 0x110 in a 2-session payload): `0e 00 02 00 00 80 3f 50 00 ...` (type_code=80)

P remapped to 2 by inference (pattern of -1 across the session_type space); not pcap-verified — feedback welcome.

Fixes thomasbourimech/assettocorsa_competizione_server#9
