### PR TITLE
fix(handlers): drop track_str from 0x56 lap-history entries

### DIFF
--- a/accd/handlers.c
+++ b/accd/handlers.c
@@ -1974,7 +1974,18 @@ h_load_setup(struct Server *s, struct Conn *c,
 				int idx = (start + k) % ACC_LAP_HISTORY;
 				int si;
 
-				if (wr_str_a(&out, s->track) < 0) goto done;
+				/*
+				 * kunos's 0x56 lap-history entry layout does
+				 * NOT include the track name string per lap.
+				 * Pcap diff against kunos accServer.exe
+				 * (zolder Q5+R10, 2026-05-25) shows each lap
+				 * entry as: u32 lap_ms + u8(3) + 3*u32 splits
+				 * + u16 carId + u8 0 + u16 lap_num.  Emitting
+				 * wr_str_a(s->track) here bloated the payload
+				 * by ~26 bytes per lap AND broke the per-lap
+				 * alignment expected by the AC2 client's
+				 * setup-data parser.
+				 */
 				if (wr_u32(&out,
 				    (uint32_t)src->lap_history_ms[idx]) < 0)
 					goto done;


### PR DESCRIPTION
Pcap diff against kunos accServer.exe (zolder Q5+R10, 2026-05-25) shows each `0x56` lap-history entry as:
```
u32 lap_ms + u8(3) + 3*u32 splits + u16 carId + u8 0 + u16 lap_num
```
— with **no track name string** per lap.

accd was emitting `wr_str_a(s->track)` before `lap_ms`, which:
- bloated each lap entry by ~26 bytes (2B length + N*4B chars UTF-32)
- broke the per-lap alignment that the AC2 client's setup-data parser expects, causing the post-lap setup data response to be parsed as garbage

## Wire dump
Wine `0x56` first bytes for a 6-lap history:
```
56 01 e9 03 06 00 a5 86 01 00 03 0e 8a 00 00 0a 7a 00 00 8c 82 00 00 e9 03 00 01 00 ...
^^ msg
   ^^ sess
      ^^^^^ car  ^^^^^ count(=6) ^^^^^^^^^^^ lap_ms ^^ split_count ^^ S1 ^^ S2 ^^ S3 ^^ car ^^ flag ^^ lap_num
```

S1+S2+S3 = 35342+31242+33420 = 100004 ≈ 100005 = lap_ms ✓

Fixes thomasbourimech/assettocorsa_competizione_server#10
